### PR TITLE
Private Dictionary support with Private Creator.

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,41 @@
               }
             },
             "additionalProperties": false
+          },
+          "dicom.privateDictionary": {
+            "description": "The list of private creator and private tags information. Key is private creator. value is object of DICOM tags. but style is ODDS00XX",
+            "type": "object",
+            "patternProperties": {
+              ".*": {
+                "description": "The list of private DICOM tags that will be used along with private tags. Each key must be an 8-digit uppercase hex string representing the DICOM group/element. but style is ODDS00XX",
+                "type": "object",
+                "patternProperties": {
+                  "^[0-9A-F]{8}$": {
+                    "type": "object",
+                    "properties": {
+                      "vr": {
+                        "description": "Value representation name, such as 'SL'.",
+                        "type": "string",
+                        "pattern": "^[A-Z]{2}$"
+                      },
+                      "name": {
+                        "description": "Element name (camelCase recommended).",
+                        "type": "string"
+                      },
+                      "forceVr": {
+                        "description": "Force this VR type for this element. Use with care.",
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "vr",
+                      "name"
+                    ]
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
           }
         }
       }

--- a/src/contentProvider.ts
+++ b/src/contentProvider.ts
@@ -4,6 +4,7 @@ import * as parser from 'dicom-parser';
 import { standardDataElements, DicomDataElements } from 'dicom-data-dictionary';
 import { EncConverter, createEncConverter } from './encConverter';
 import { buildTreeFromDataSet, ParsedElement } from './extractor';
+import { PrivateTagDict } from "./privateTagDict";
 
 /**
  * Transforms the parsed elements into indented text.
@@ -62,6 +63,7 @@ export default class DicomContentProvider
     const config = vscode.workspace.getConfiguration('dicom');
     const additionalDict: DicomDataElements = config.get('dictionary') || {};
     const dictionary = Object.assign({}, standardDataElements, additionalDict);
+    const privateDictionary: PrivateTagDict = config.get('privateDictionary') || {};
     const showPrivateTags = !!config.get('showPrivateTags');
 
     if (!(uri instanceof vscode.Uri)) return '';
@@ -92,6 +94,7 @@ export default class DicomContentProvider
       rootDataSet,
       showPrivateTags,
       dictionary,
+      privateDictionary,
       encConverter
     });
 

--- a/src/privateTagDict.ts
+++ b/src/privateTagDict.ts
@@ -1,0 +1,6 @@
+import { DicomDataElements } from 'dicom-data-dictionary';
+
+export interface PrivateTagDict {
+
+    [privateCreator: string]: DicomDataElements | undefined;
+}


### PR DESCRIPTION
Current additional tag dictionary by setting doesn't solve private tag and private creator.
To extend it, dicom.privateDictionary is added in setting.

    "dicom.privateDictionary": {

        "PRIVATE_CREATOR": {
            "ODDS00XX": {
                "vr": "LO",
                "name": "name and description"
            }
        }
    }